### PR TITLE
Store signer on /verify, abort early if no PDA

### DIFF
--- a/api/src/api/handlers/async_verify.rs
+++ b/api/src/api/handlers/async_verify.rs
@@ -7,39 +7,80 @@ use crate::errors::ErrorMessages;
 use crate::services::onchain;
 use crate::services::verification::{check_and_handle_duplicates, check_and_process_verification};
 use axum::{extract::State, http::StatusCode, Json};
-use solana_sdk::system_program;
 
 // Route handler for POST /verify which creates a new process to verify the program
 pub(crate) async fn process_async_verification(
     State(db): State<DbClient>,
     Json(payload): Json<SolanaProgramBuildParams>,
 ) -> (StatusCode, Json<ApiResponse>) {
-    process_verification(db, payload, None).await
+    let params_from_onchain = onchain::get_otter_verify_params(&payload.program_id, None)
+        .await
+        .map_err(|err| {
+            tracing::error!(
+                "Unable to find on-chain PDA for given program id: {:?}",
+                err
+            );
+            (
+                StatusCode::NOT_FOUND,
+                Json(
+                    ErrorResponse {
+                        status: Status::Error,
+                        error: ErrorMessages::NoPDA.to_string(),
+                    }
+                    .into(),
+                ),
+            )
+        });
+
+    match params_from_onchain {
+        Ok((params, signer)) => {
+            process_verification(db, SolanaProgramBuildParams::from(params), signer).await
+        }
+        Err(e) => e,
+    }
 }
 
 pub(crate) async fn process_async_verification_with_signer(
     State(db): State<DbClient>,
     Json(payload): Json<SolanaProgramBuildParamsWithSigner>,
 ) -> (StatusCode, Json<ApiResponse>) {
-    process_verification(db, payload.params, Some(payload.signer)).await
+    let program_id = payload.program_id.clone();
+    let signer = payload.signer.clone();
+    let params_from_onchain =
+        onchain::get_otter_verify_params(&program_id, Some(signer.clone())).await;
+
+    match params_from_onchain {
+        Ok((params, _)) => {
+            process_verification(db, SolanaProgramBuildParams::from(params), signer).await
+        }
+        Err(e) => {
+            tracing::error!("Error fetching onchain params: {:?}", e);
+            (
+                StatusCode::OK,
+                Json(
+                    ErrorResponse {
+                        status: Status::Error,
+                        error: ErrorMessages::NoPDA.to_string(),
+                    }
+                    .into(),
+                ),
+            )
+        }
+    }
 }
 
 async fn process_verification(
     db: DbClient,
     payload: SolanaProgramBuildParams,
-    signer: Option<String>,
+    signer: String,
 ) -> (StatusCode, Json<ApiResponse>) {
-    let mut payload = SolanaProgramBuildParamsWithSigner {
-        params: payload,
-        signer: signer.clone().unwrap_or(system_program::id().to_string()),
-    };
-    let verify_build_data = SolanaProgramBuild::from(&payload);
+    let mut verify_build_data = SolanaProgramBuild::from(&payload);
+    verify_build_data.signer = Some(signer.clone());
+
     let mut uuid = verify_build_data.id.clone();
 
     // Check if the build was already processed
-    let is_dublicate = check_and_handle_duplicates(&payload, &db).await;
-
-    if let Some(response) = is_dublicate {
+    if let Some(response) = check_and_handle_duplicates(&payload, signer.clone(), &db).await {
         return (StatusCode::OK, Json(response.into()));
     }
 
@@ -58,61 +99,31 @@ async fn process_verification(
         );
     }
 
+    // Updated the build status to completed for recieved build params and update the uuid to a new one
+    let _ = db
+        .update_build_status(&uuid, JobStatus::Completed.into())
+        .await
+        .map_err(|e| {
+            tracing::error!("Error updating build status: {:?}", e);
+            e
+        });
+
+    // Insert the new build params into the database and update the uuid
+    let mut new_build = SolanaProgramBuild::from(&payload);
+    new_build.signer = Some(signer.clone());
+    let _ = db.insert_build_params(&new_build).await;
+    uuid = new_build.id.clone();
+
     // Now check if there was a PDA associated with that Build if so we need to handle it
-    let params_from_onchain =
-        onchain::get_otter_verify_params(&verify_build_data.program_id, signer.clone()).await;
-
-    match params_from_onchain {
-        Ok(params) => {
-            tracing::info!("{:?} using Otter params", params);
-            payload.params = SolanaProgramBuildParams::from(params);
-
-            // check if the params was already processed
-            let is_duplicate = check_and_handle_duplicates(&payload, &db).await;
-            if let Some(response) = is_duplicate {
-                return (StatusCode::OK, Json(response.into()));
-            }
-
-            // Updated the build status to completed for recieved build params and update the uuid to a new one
-            let _ = db
-                .update_build_status(&uuid, JobStatus::Completed.into())
-                .await
-                .map_err(|e| {
-                    tracing::error!("Error updating build status: {:?}", e);
-                    e
-                });
-
-            // Insert the new build params into the database and update the uuid
-            let new_build = SolanaProgramBuild::from(&payload);
-            let _ = db.insert_build_params(&new_build).await;
-            uuid = new_build.id.clone();
-        }
-        Err(e) => {
-            if signer.is_some() {
-                tracing::error!("Error fetching onchain params: {:?}", e);
-                return (
-                    StatusCode::OK,
-                    Json(
-                        ErrorResponse {
-                            status: Status::Error,
-                            error: ErrorMessages::NoPDA.to_string(),
-                        }
-                        .into(),
-                    ),
-                );
-            }
-        }
-    }
-
     //run task in background
     let req_id = uuid.clone();
     tokio::spawn(async move {
         tracing::info!(
             "Spawning verification task with signer: {:?} and uuid: {:?}",
-            signer,
-            uuid
+            &signer,
+            &uuid
         );
-        let _ = check_and_process_verification(payload.params, &uuid, &db).await;
+        let _ = check_and_process_verification(payload, &uuid, &db).await;
     });
 
     (

--- a/api/src/api/handlers/sync_verify.rs
+++ b/api/src/api/handlers/sync_verify.rs
@@ -1,6 +1,6 @@
 use crate::db::models::{
-    ApiResponse, ErrorResponse, SolanaProgramBuild, SolanaProgramBuildParams,
-    SolanaProgramBuildParamsWithSigner, Status, StatusResponse, DEFAULT_SIGNER,
+    ApiResponse, ErrorResponse, SolanaProgramBuild, SolanaProgramBuildParams, Status,
+    StatusResponse, DEFAULT_SIGNER,
 };
 use crate::db::DbClient;
 use crate::errors::ErrorMessages;
@@ -15,14 +15,7 @@ pub(crate) async fn process_sync_verification(
     let uuid = verify_build_data.id.clone();
 
     // First check if the program is already verified
-    let is_dublicate = check_and_handle_duplicates(
-        &SolanaProgramBuildParamsWithSigner {
-            params: payload.clone(),
-            signer: DEFAULT_SIGNER.to_string(),
-        },
-        &db,
-    )
-    .await;
+    let is_dublicate = check_and_handle_duplicates(&payload, DEFAULT_SIGNER.to_string(), &db).await;
 
     if let Some(response) = is_dublicate {
         return (StatusCode::OK, Json(response.into()));

--- a/api/src/db/models/db_models.rs
+++ b/api/src/db/models/db_models.rs
@@ -4,7 +4,7 @@ use diesel::prelude::*;
 use serde::{Deserialize, Serialize};
 use solana_sdk::{pubkey::Pubkey, system_program};
 
-use super::{SolanaProgramBuildParams, SolanaProgramBuildParamsWithSigner};
+use super::SolanaProgramBuildParams;
 
 pub(crate) const DEFAULT_SIGNER: Pubkey = system_program::id();
 
@@ -53,14 +53,6 @@ impl<'a> From<&'a SolanaProgramBuildParams> for SolanaProgramBuild {
             status: JobStatus::InProgress.into(),
             signer: Some(DEFAULT_SIGNER.to_string()),
         }
-    }
-}
-
-impl<'a> From<&'a SolanaProgramBuildParamsWithSigner> for SolanaProgramBuild {
-    fn from(body: &'a SolanaProgramBuildParamsWithSigner) -> Self {
-        let mut build = SolanaProgramBuild::from(&body.params);
-        build.signer = Some(body.signer.clone());
-        build
     }
 }
 

--- a/api/src/db/models/params.rs
+++ b/api/src/db/models/params.rs
@@ -16,8 +16,7 @@ pub struct SolanaProgramBuildParams {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SolanaProgramBuildParamsWithSigner {
     pub signer: String,
-    #[serde(flatten)]
-    pub params: SolanaProgramBuildParams,
+    pub program_id: String,
 }
 
 impl From<OtterBuildParams> for SolanaProgramBuildParams {

--- a/api/src/db/params.rs
+++ b/api/src/db/params.rs
@@ -1,4 +1,4 @@
-use super::models::SolanaProgramBuildParamsWithSigner;
+use super::models::SolanaProgramBuildParams;
 use super::DbClient;
 use crate::db::models::SolanaProgramBuild;
 use crate::Result;
@@ -19,12 +19,13 @@ impl DbClient {
 
     pub async fn check_for_duplicate(
         &self,
-        data: &SolanaProgramBuildParamsWithSigner,
+        data: &SolanaProgramBuildParams,
+        pda_signer: String,
     ) -> Result<SolanaProgramBuild> {
         use crate::schema::solana_program_builds::dsl::*;
 
         let conn = &mut self.db_pool.get().await?;
-        let payload = &data.params;
+        let payload = &data;
 
         let mut query = solana_program_builds.into_boxed();
 
@@ -55,7 +56,7 @@ impl DbClient {
             query = query.filter(cargo_args.eq(args));
         }
 
-        query = query.filter(signer.eq(data.signer.clone()));
+        query = query.filter(signer.eq(pda_signer.clone()));
 
         query
             .order(created_at.desc())

--- a/api/src/db/verification.rs
+++ b/api/src/db/verification.rs
@@ -301,7 +301,7 @@ impl DbClient {
         // Get the build params from the on-chain Metadata
         let params_from_onchain = onchain::get_otter_verify_params(&payload.program_id, None).await;
 
-        if let Ok(params_from_onchain) = params_from_onchain {
+        if let Ok((params_from_onchain, _)) = params_from_onchain {
             // Compare the build params from on-chain and the build params from the database
             let otter_params = SolanaProgramBuildParams::from(params_from_onchain);
             if otter_params != payload {

--- a/api/src/services/verification.rs
+++ b/api/src/services/verification.rs
@@ -1,7 +1,4 @@
-use crate::db::models::{
-    JobStatus, SolanaProgramBuildParams, SolanaProgramBuildParamsWithSigner, VerifiedProgram,
-    VerifyResponse,
-};
+use crate::db::models::{JobStatus, SolanaProgramBuildParams, VerifiedProgram, VerifyResponse};
 use crate::db::DbClient;
 use crate::errors::ApiError;
 use crate::errors::ErrorMessages;
@@ -44,11 +41,12 @@ pub async fn check_and_process_verification(
 }
 
 pub async fn check_and_handle_duplicates(
-    payload: &SolanaProgramBuildParamsWithSigner,
+    payload: &SolanaProgramBuildParams,
+    signer: String,
     db: &DbClient,
 ) -> Option<VerifyResponse> {
     // Check if the build was already processed
-    let is_duplicate = db.check_for_duplicate(payload).await;
+    let is_duplicate = db.check_for_duplicate(payload, signer).await;
 
     if let Ok(respose) = is_duplicate {
         match respose.status.into() {


### PR DESCRIPTION
Fixes bug where API would hang when `/verify` was submitted w/o signer