### PR TITLE
feat: install necessary docker dependencies

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -7,6 +7,10 @@ COPY api ./api
 
 COPY .env .
 
+# Install necessary dependencies
+RUN apt-get update && \
+    apt-get install -y pkg-config libssl-dev build-essential
+
 WORKDIR /solana_verified_program_api/api
 
 RUN cargo build --release


### PR DESCRIPTION
background:
I was trying to build this Docker image and encountered a 'docker build failed' error. It seemed there were no OpenSSL dependencies installed. After I added `apt-get install` to the Dockerfile, it was fixed.

environment: 
chip: Apple M2 Max
macos: 14.6.1 
docker version: v4.37.2

errors:
169.5 The following warnings were emitted during compilation: 
169.5 warning: openssl-sys@0.9.103: building OpenSSL: 'make' reported failure with exit status: 2 
169.5 warning: openssl-sys@0.9.103: openssl-src: failed to build OpenSSL from source 
169.5 error: failed to run custom build command for openssl-sys v0.9.103 
169.5 Caused by: 
169.5 process didn't exit successfully