### PR TITLE
Update solana-verify to v0.4.15

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /solana_verified_program_api/api
 
 RUN cargo build --release
 
-RUN cargo install solana-verify --git https://github.com/solana-foundation/solana-verifiable-build --tag v0.4.12
+RUN cargo install solana-verify --git https://github.com/solana-foundation/solana-verifiable-build --tag v0.4.15
 
 FROM debian:stable-slim AS api_final
 


### PR DESCRIPTION
This PR updates the solana-verify version in `api/Dockerfile` to **v0.4.15**.

Triggered from a release in [solana-foundation/solana-verifiable-build](https://github.com/solana-foundation/solana-verifiable-build).

Before merging, please run:
`docker build -f api/Dockerfile .`