### PR TITLE
v2: `resolve-hash` endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`GET /resolve-hash/{executable_hash}` endpoint**: content-addressed lookup over the verified-build catalogue. Given a 64-char executable hash, returns every completed build that produced it, each flagged with `matches_deployed` (true when the hash matches the program's currently-deployed on-chain hash).
+
 ## [1.5.4] - 2026-06-23
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ curl https://verify.osec.io/verified-programs/1 | jq
 curl https://verify.osec.io/verified-programs-status | jq
 ```
 
+#### Resolve Executable Hash
+Content-addressed lookup. Given an executable hash, returns every completed build that produced it, with a `matches_deployed` flag indicating whether that hash is what's currently deployed on its program.
+```bash
+curl https://verify.osec.io/resolve-hash/29e7713aa3c48e242e2847bc031fe2a03eb61aae5ecaec8728131e16934de465 | jq
+```
+
 ### Rate Limits
 
 - **Verification endpoints**: 5 requests/second globally, 1 request per 30 seconds per IP

--- a/src/api/handlers/index.rs
+++ b/src/api/handlers/index.rs
@@ -203,6 +203,18 @@ pub fn index() -> Json<Value> {
                     }
                 },
                 {
+                    "path": "/resolve-hash/:hash",
+                    "method": "GET",
+                    "description": "Content-addressed lookup: every completed build that produced the given executable hash",
+                    "params": {
+                        "hash": {
+                            "type": "string",
+                            "required": true,
+                            "description": "Executable hash (hex-encoded sha256)"
+                        }
+                    }
+                },
+                {
                     "path": "/job/:job_id",
                     "method": "GET",
                     "description": "Check status of an async verification job",

--- a/src/api/handlers/mod.rs
+++ b/src/api/handlers/mod.rs
@@ -14,6 +14,7 @@ pub mod health; // Health check and background job status
 pub mod job_status; // Build job status
 pub mod logs; // Build logs retrieval
 pub mod pda_worker;
+pub mod resolve_hash; // GET /resolve-hash/{hash}
 pub mod verified_programs_list; // List of verified programs
 pub mod verified_programs_status; // Status of verified programs // PDA updates/creations
 

--- a/src/api/handlers/resolve_hash.rs
+++ b/src/api/handlers/resolve_hash.rs
@@ -1,0 +1,49 @@
+//! `GET /resolve-hash/{hash}` -- content-addressed lookup: every completed
+//! build that produced a given executable hash.
+
+use crate::{
+    api::responses::{ResolveHashEntry, ResolveHashResponse},
+    db::DbClient,
+    errors::{ApiError, Result},
+};
+use axum::{
+    extract::{Path, State},
+    Json,
+};
+
+pub async fn resolve(
+    State(db): State<DbClient>,
+    Path(hash): Path<String>,
+) -> Result<Json<ResolveHashResponse>> {
+    let hash = hash.trim().to_string();
+    if hash.is_empty() {
+        return Err(ApiError::BadRequest("hash cannot be empty".into()));
+    }
+
+    let builds = db.builds_by_executable_hash(&hash).await?;
+    let mut entries = Vec::with_capacity(builds.len());
+    for b in builds {
+        let on_chain_hash = db
+            .get_program_state(&b.program_id)
+            .await
+            .ok()
+            .flatten()
+            .and_then(|s| s.on_chain_hash);
+        let matches_deployed = on_chain_hash.as_deref() == Some(hash.as_str());
+
+        entries.push(ResolveHashEntry {
+            build_id: b.id.to_string(),
+            program_id: b.program_id,
+            signer: b.signer,
+            repository: b.repository,
+            commit: b.commit_hash,
+            completed_at: b.completed_at.map(|t| t.naive_utc()),
+            matches_deployed,
+        });
+    }
+
+    Ok(Json(ResolveHashResponse {
+        executable_hash: hash,
+        builds: entries,
+    }))
+}

--- a/src/api/handlers/resolve_hash.rs
+++ b/src/api/handlers/resolve_hash.rs
@@ -15,32 +15,27 @@ pub async fn resolve(
     State(db): State<DbClient>,
     Path(hash): Path<String>,
 ) -> Result<Json<ResolveHashResponse>> {
-    let hash = hash.trim().to_string();
-    if hash.is_empty() {
-        return Err(ApiError::BadRequest("hash cannot be empty".into()));
+    // Stored hashes are lowercase hex; reject non-hex up front (400, no query).
+    let hash = hash.trim().to_lowercase();
+    if hash.len() != 64 || !hash.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return Err(ApiError::BadRequest(
+            "executable_hash must be a 64-character hex string".into(),
+        ));
     }
 
-    let builds = db.builds_by_executable_hash(&hash).await?;
-    let mut entries = Vec::with_capacity(builds.len());
-    for b in builds {
-        let on_chain_hash = db
-            .get_program_state(&b.program_id)
-            .await
-            .ok()
-            .flatten()
-            .and_then(|s| s.on_chain_hash);
-        let matches_deployed = on_chain_hash.as_deref() == Some(hash.as_str());
-
-        entries.push(ResolveHashEntry {
+    let builds = db.resolve_executable_hash(&hash).await?;
+    let entries = builds
+        .into_iter()
+        .map(|b| ResolveHashEntry {
             build_id: b.id.to_string(),
             program_id: b.program_id,
             signer: b.signer,
             repository: b.repository,
             commit: b.commit_hash,
             completed_at: b.completed_at.map(|t| t.naive_utc()),
-            matches_deployed,
-        });
-    }
+            matches_deployed: b.matches_deployed,
+        })
+        .collect();
 
     Ok(Json(ResolveHashResponse {
         executable_hash: hash,

--- a/src/api/handlers/resolve_hash.rs
+++ b/src/api/handlers/resolve_hash.rs
@@ -2,7 +2,7 @@
 //! build that produced a given executable hash.
 
 use crate::{
-    api::responses::{ResolveHashEntry, ResolveHashResponse},
+    api::responses::ResolveHashResponse,
     db::DbClient,
     errors::{ApiError, Result},
 };
@@ -24,18 +24,7 @@ pub async fn resolve(
     }
 
     let builds = db.resolve_executable_hash(&hash).await?;
-    let entries = builds
-        .into_iter()
-        .map(|b| ResolveHashEntry {
-            build_id: b.id.to_string(),
-            program_id: b.program_id,
-            signer: b.signer,
-            repository: b.repository,
-            commit: b.commit_hash,
-            completed_at: b.completed_at.map(|t| t.naive_utc()),
-            matches_deployed: b.matches_deployed,
-        })
-        .collect();
+    let entries = builds.into_iter().map(Into::into).collect();
 
     Ok(Json(ResolveHashResponse {
         executable_hash: hash,

--- a/src/api/responses.rs
+++ b/src/api/responses.rs
@@ -389,6 +389,7 @@ pub struct ResolveHashEntry {
     pub commit: Option<String>,
     pub completed_at: Option<NaiveDateTime>,
     pub matches_deployed: bool,
+    pub trusted: bool,
 }
 
 impl From<ResolvedBuildRow> for ResolveHashEntry {
@@ -401,6 +402,7 @@ impl From<ResolvedBuildRow> for ResolveHashEntry {
             commit: b.commit_hash,
             completed_at: b.completed_at.map(|t| t.naive_utc()),
             matches_deployed: b.matches_deployed,
+            trusted: b.trusted,
         }
     }
 }

--- a/src/api/responses.rs
+++ b/src/api/responses.rs
@@ -370,3 +370,23 @@ pub struct BackgroundJobHealth {
     pub last_program_check: Option<NaiveDateTime>,
     pub message: String,
 }
+
+/// Response shape for `GET /resolve-hash/{executable_hash}`.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ResolveHashResponse {
+    pub executable_hash: String,
+    pub builds: Vec<ResolveHashEntry>,
+}
+
+/// `matches_deployed` is true when this build's hash matches its
+/// program's cached `on_chain_hash`.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ResolveHashEntry {
+    pub build_id: String,
+    pub program_id: crate::types::Address,
+    pub signer: Option<crate::types::Address>,
+    pub repository: String,
+    pub commit: Option<String>,
+    pub completed_at: Option<NaiveDateTime>,
+    pub matches_deployed: bool,
+}

--- a/src/api/responses.rs
+++ b/src/api/responses.rs
@@ -2,7 +2,7 @@ use chrono::NaiveDateTime;
 use serde::{Deserialize, Serialize};
 
 pub use crate::db::JobStatus;
-use crate::db::{BuildRow, ProgramStateRow};
+use crate::db::{BuildRow, ProgramStateRow, ResolvedBuildRow};
 use crate::types::Address;
 
 /// Formats `repo/tree/<commit>` for display in `/status`-style responses.
@@ -389,4 +389,18 @@ pub struct ResolveHashEntry {
     pub commit: Option<String>,
     pub completed_at: Option<NaiveDateTime>,
     pub matches_deployed: bool,
+}
+
+impl From<ResolvedBuildRow> for ResolveHashEntry {
+    fn from(b: ResolvedBuildRow) -> Self {
+        Self {
+            build_id: b.id.to_string(),
+            program_id: b.program_id,
+            signer: b.signer,
+            repository: b.repository,
+            commit: b.commit_hash,
+            completed_at: b.completed_at.map(|t| t.naive_utc()),
+            matches_deployed: b.matches_deployed,
+        }
+    }
 }

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -110,6 +110,7 @@ pub fn initialize_router(state: AppState) -> Router {
         )
         .route("/status-all/{address}", get(get_verification_status_all))
         .route("/status/{address}", get(get_verification_status))
+        .route("/resolve-hash/{hash}", get(resolve_hash::resolve))
         .route("/job/{job_id}", get(get_job_status))
         .route("/logs/{build_id}", get(get_build_logs))
         .route("/pda", post(handle_pda_updates_creations))

--- a/src/db.rs
+++ b/src/db.rs
@@ -332,6 +332,18 @@ impl DbClient {
         .await?)
     }
 
+    /// Every completed build with this executable hash.
+    pub async fn builds_by_executable_hash(&self, hash: &str) -> Result<Vec<BuildRow>> {
+        Ok(sqlx::query_as::<_, BuildRow>(
+            "SELECT * FROM builds
+             WHERE executable_hash = $1 AND status = 'completed'
+             ORDER BY completed_at DESC",
+        )
+        .bind(hash)
+        .fetch_all(&self.pool)
+        .await?)
+    }
+
     /// Clears the `pending_reverify` flag once the sweep has acted on a
     /// program (kicked a build, or decided there was nothing to do). It only
     /// comes back via a fresh drift in [`upsert_program_state`].

--- a/src/db.rs
+++ b/src/db.rs
@@ -114,6 +114,7 @@ pub struct ResolvedBuildRow {
     pub commit_hash: Option<String>,
     pub completed_at: Option<DateTime<Utc>>,
     pub matches_deployed: bool,
+    pub trusted: bool,
 }
 
 /// Subset of `program_state` callers actually read. `authority` and
@@ -345,24 +346,29 @@ impl DbClient {
         .await?)
     }
 
-    /// Every completed build with this executable hash, each flagged for
-    /// whether the hash matches the program's on-chain hash. One query: index
-    /// lookup + `LEFT JOIN program_state`, no per-build round-trip.
+    /// Every completed build with this executable hash, each flagged with
+    /// `matches_deployed` and `trusted`. One query: index lookup + `LEFT JOIN
+    /// program_state`, no per-build round-trip.
     ///
-    /// `matches_deployed` is false for a closed program (`NOT ps.is_closed`):
-    /// a closed program can retain a stale cached `on_chain_hash`, and a hash
-    /// can't be "deployed" to a program that no longer exists.
+    /// `matches_deployed` is false for a closed program (the stale cached hash
+    /// can't be "deployed" anywhere). `trusted` mirrors the verified-ness check:
+    /// signer is null, whitelisted, or the program's authority.
     pub async fn resolve_executable_hash(&self, hash: &str) -> Result<Vec<ResolvedBuildRow>> {
+        let trusted = trusted_signers();
         Ok(sqlx::query_as::<_, ResolvedBuildRow>(
             "SELECT b.id, b.program_id, b.signer, b.repository, b.commit_hash, b.completed_at,
                     COALESCE(ps.on_chain_hash = b.executable_hash AND NOT ps.is_closed, false)
-                        AS matches_deployed
+                        AS matches_deployed,
+                    (b.signer IS NULL
+                     OR b.signer = ANY($2)
+                     OR b.signer IS NOT DISTINCT FROM ps.authority) AS trusted
              FROM builds b
              LEFT JOIN program_state ps ON ps.program_id = b.program_id
              WHERE b.executable_hash = $1 AND b.status = 'completed'
              ORDER BY b.completed_at DESC",
         )
         .bind(hash)
+        .bind(&trusted)
         .fetch_all(&self.pool)
         .await?)
     }

--- a/src/db.rs
+++ b/src/db.rs
@@ -495,9 +495,9 @@ impl DbClient {
         .await?)
     }
 
-    /// Full refresh from a snapshot. A `None` hash on the snapshot preserves
-    /// the existing column rather than clobbering it, so a transient hash
-    /// fetch failure doesn't lose previously known data.
+    /// Full refresh from a snapshot. A `None` hash or authority keeps the
+    /// stored value rather than clobbering it -- the sweep can't re-derive a
+    /// burned authority, only the verify path does.
     ///
     /// Flips `pending_reverify` TRUE when the incoming hash actually differs
     /// from the stored one -- that's the sweep's drift signal, drained by
@@ -514,7 +514,7 @@ impl DbClient {
              VALUES ($1, $2, $3, $4, $5, NOW())
              ON CONFLICT (program_id) DO UPDATE
              SET on_chain_hash = COALESCE(EXCLUDED.on_chain_hash, program_state.on_chain_hash),
-                 authority     = EXCLUDED.authority,
+                 authority     = COALESCE(EXCLUDED.authority, program_state.authority),
                  is_frozen     = EXCLUDED.is_frozen,
                  is_closed     = EXCLUDED.is_closed,
                  last_checked  = NOW(),

--- a/src/db.rs
+++ b/src/db.rs
@@ -103,6 +103,19 @@ pub struct BuildRow {
     pub completed_at: Option<DateTime<Utc>>,
 }
 
+/// A completed build for a given executable hash, with `matches_deployed`
+/// (hash == the program's on-chain hash) computed in the join.
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct ResolvedBuildRow {
+    pub id: Uuid,
+    pub program_id: Address,
+    pub signer: Option<Address>,
+    pub repository: String,
+    pub commit_hash: Option<String>,
+    pub completed_at: Option<DateTime<Utc>>,
+    pub matches_deployed: bool,
+}
+
 /// Subset of `program_state` callers actually read. `authority` and
 /// `last_checked` exist on the row but aren't surfaced anywhere yet.
 #[derive(Debug, Clone, sqlx::FromRow)]
@@ -332,12 +345,17 @@ impl DbClient {
         .await?)
     }
 
-    /// Every completed build with this executable hash.
-    pub async fn builds_by_executable_hash(&self, hash: &str) -> Result<Vec<BuildRow>> {
-        Ok(sqlx::query_as::<_, BuildRow>(
-            "SELECT * FROM builds
-             WHERE executable_hash = $1 AND status = 'completed'
-             ORDER BY completed_at DESC",
+    /// Every completed build with this executable hash, each flagged for
+    /// whether the hash matches the program's on-chain hash. One query: index
+    /// lookup + `LEFT JOIN program_state`, no per-build round-trip.
+    pub async fn resolve_executable_hash(&self, hash: &str) -> Result<Vec<ResolvedBuildRow>> {
+        Ok(sqlx::query_as::<_, ResolvedBuildRow>(
+            "SELECT b.id, b.program_id, b.signer, b.repository, b.commit_hash, b.completed_at,
+                    COALESCE(ps.on_chain_hash = b.executable_hash, false) AS matches_deployed
+             FROM builds b
+             LEFT JOIN program_state ps ON ps.program_id = b.program_id
+             WHERE b.executable_hash = $1 AND b.status = 'completed'
+             ORDER BY b.completed_at DESC",
         )
         .bind(hash)
         .fetch_all(&self.pool)

--- a/src/db.rs
+++ b/src/db.rs
@@ -348,10 +348,15 @@ impl DbClient {
     /// Every completed build with this executable hash, each flagged for
     /// whether the hash matches the program's on-chain hash. One query: index
     /// lookup + `LEFT JOIN program_state`, no per-build round-trip.
+    ///
+    /// `matches_deployed` is false for a closed program (`NOT ps.is_closed`):
+    /// a closed program can retain a stale cached `on_chain_hash`, and a hash
+    /// can't be "deployed" to a program that no longer exists.
     pub async fn resolve_executable_hash(&self, hash: &str) -> Result<Vec<ResolvedBuildRow>> {
         Ok(sqlx::query_as::<_, ResolvedBuildRow>(
             "SELECT b.id, b.program_id, b.signer, b.repository, b.commit_hash, b.completed_at,
-                    COALESCE(ps.on_chain_hash = b.executable_hash, false) AS matches_deployed
+                    COALESCE(ps.on_chain_hash = b.executable_hash AND NOT ps.is_closed, false)
+                        AS matches_deployed
              FROM builds b
              LEFT JOIN program_state ps ON ps.program_id = b.program_id
              WHERE b.executable_hash = $1 AND b.status = 'completed'


### PR DESCRIPTION
Stacked on top of #126. Adds a single new endpoint and supporting wiring.

## `GET /resolve-hash/{executable_hash}`

Content-addressed lookup. Given any 64-char executable hash, returns every completed build that produced it, with a `matches_deployed` flag set true when that hash equals the program's currently-deployed on-chain hash. Lets consumers hash any `.so` (deployed program, local build, downloaded artifact) and ask "who has claimed this is reproducible, and against which program?"

```json
{
  "executable_hash": "29e7713a...",
  "builds": [
    {
      "build_id": "uuid",
      "program_id": "12wpf4...",
      "signer": "...",
      "repository": "https://github.com/...",
      "commit": "a5b38f...",
      "completed_at": "2025-...",
      "matches_deployed": true
    }
  ]
}
```

Backed by `builds_executable_hash_idx`: one index lookup for the matching builds, then one `program_state` row fetch per build to populate `matches_deployed`.