### PR TITLE
Update solana-verify to v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.5] - 2026-06-26
+
+### Changed
+
+- **`solana-verify` version:** bumped from `v0.5.0` to `v0.5.1` in the `Dockerfile`.
+
 ## [1.5.4] - 2026-06-23
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY . .
 
 RUN cargo build --release
 
-RUN cargo install solana-verify --git https://github.com/solana-foundation/solana-verifiable-build --tag v0.5.0
+RUN cargo install solana-verify --git https://github.com/solana-foundation/solana-verifiable-build --tag v0.5.1
 
 FROM debian:stable-slim AS api_final
 


### PR DESCRIPTION
This PR updates the solana-verify version in `api/Dockerfile` to **v0.5.1**.

Triggered from a release in [solana-foundation/solana-verifiable-build](https://github.com/solana-foundation/solana-verifiable-build).

Before merging, please run:
`docker build -f api/Dockerfile .`