### PR TITLE
  Backport workspace path support to v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.5] - 2026-06-29
+
+### Added
+
+- **Workspace path support** for monorepo verification: requests can now include `workspace_path`, build records persist it, and verification passes it to `solana-verify --workspace-path`.
+
 ## [1.5.4] - 2026-06-23
 
 ### Fixed

--- a/migrations/0001_init.sql
+++ b/migrations/0001_init.sql
@@ -20,6 +20,7 @@ CREATE TABLE IF NOT EXISTS builds (
     lib_name          TEXT,
     base_docker_image TEXT,
     mount_path        TEXT,
+    workspace_path    TEXT,
     cargo_args        TEXT[],
     bpf_flag          BOOLEAN NOT NULL DEFAULT FALSE,
     arch              TEXT,

--- a/src/api/handlers/index.rs
+++ b/src/api/handlers/index.rs
@@ -130,11 +130,21 @@ pub fn index() -> Json<Value> {
                             "required": false,
                             "description": "Custom mount path for repository in build container"
                         },
+                        "workspace_path": {
+                            "type": "string",
+                            "required": false,
+                            "description": "Custom workspace path for monorepos. Passed to solana-verify --workspace-path"
+                        },
                         "cargo_args": {
                             "type": "array",
                             "items": "string",
                             "required": false,
-                            "description": "Additional cargo build arguments"
+                            "description": "Additional cargo build arguments passed after solana-verify --"
+                        },
+                        "cargo_build_sbf_args": {
+                            "type": "string",
+                            "required": false,
+                            "description": "Arguments passed to solana-verify --cargo-build-sbf-args"
                         },
                         "arch": {
                             "type": "string",

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -118,6 +118,9 @@ fn build_command(p: &NewBuild, rpc_url: &str) -> Command {
     if let Some(mp) = &p.mount_path {
         cmd.arg("--mount-path").arg(mp);
     }
+    if let Some(wp) = &p.workspace_path {
+        cmd.arg("--workspace-path").arg(wp);
+    }
     if p.bpf_flag {
         cmd.arg("--bpf");
     }

--- a/src/db.rs
+++ b/src/db.rs
@@ -92,6 +92,7 @@ pub struct BuildRow {
     pub lib_name: Option<String>,
     pub base_docker_image: Option<String>,
     pub mount_path: Option<String>,
+    pub workspace_path: Option<String>,
     pub cargo_args: Option<Vec<String>>,
     pub bpf_flag: bool,
     pub arch: Option<String>,
@@ -135,6 +136,7 @@ pub struct NewBuild {
     pub lib_name: Option<String>,
     pub base_docker_image: Option<String>,
     pub mount_path: Option<String>,
+    pub workspace_path: Option<String>,
     pub cargo_args: Option<Vec<String>>,
     /// Passed to `solana-verify` as `--cargo-build-sbf-args=...`. Sourced from
     /// the on-chain PDA only; not persisted, so it's `None` on re-verification.
@@ -153,6 +155,7 @@ impl From<&OtterBuildParams> for NewBuild {
             lib_name: p.get_library_name(),
             base_docker_image: p.get_base_image(),
             mount_path: p.get_mount_path(),
+            workspace_path: p.get_workspace_path(),
             cargo_args: p.get_cargo_args(),
             cargo_build_sbf_args: p.get_cargo_build_sbf_args(),
             bpf_flag: p.is_bpf(),
@@ -169,9 +172,9 @@ impl DbClient {
         sqlx::query(
             "INSERT INTO builds (
                 id, repository, commit_hash, program_id, lib_name,
-                base_docker_image, mount_path, cargo_args, bpf_flag, arch,
+                base_docker_image, mount_path, workspace_path, cargo_args, bpf_flag, arch,
                 signer, status
-            ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)",
+            ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)",
         )
         .bind(id)
         .bind(&b.repository)
@@ -180,6 +183,7 @@ impl DbClient {
         .bind(&b.lib_name)
         .bind(&b.base_docker_image)
         .bind(&b.mount_path)
+        .bind(&b.workspace_path)
         .bind(&b.cargo_args)
         .bind(b.bpf_flag)
         .bind(&b.arch)
@@ -264,7 +268,7 @@ impl DbClient {
 
     /// Most recent build with identical params. `include_failed = false`
     /// ignores failed rows (they're retryable); `true` counts every status.
-    /// `$11` toggles the failed filter so both callers share one query.
+    /// `$12` toggles the failed filter so both callers share one query.
     async fn latest_build_for_params(
         &self,
         b: &NewBuild,
@@ -278,11 +282,12 @@ impl DbClient {
                AND (lib_name          IS NOT DISTINCT FROM $4)
                AND (base_docker_image IS NOT DISTINCT FROM $5)
                AND (mount_path        IS NOT DISTINCT FROM $6)
-               AND (cargo_args        IS NOT DISTINCT FROM $7)
-               AND bpf_flag = $8
-               AND (arch              IS NOT DISTINCT FROM $9)
-               AND (signer            IS NOT DISTINCT FROM $10)
-               AND ($11 OR status <> 'failed')
+               AND (workspace_path    IS NOT DISTINCT FROM $7)
+               AND (cargo_args        IS NOT DISTINCT FROM $8)
+               AND bpf_flag = $9
+               AND (arch              IS NOT DISTINCT FROM $10)
+               AND (signer            IS NOT DISTINCT FROM $11)
+               AND ($12 OR status <> 'failed')
              ORDER BY created_at DESC
              LIMIT 1",
         )
@@ -292,6 +297,7 @@ impl DbClient {
         .bind(&b.lib_name)
         .bind(&b.base_docker_image)
         .bind(&b.mount_path)
+        .bind(&b.workspace_path)
         .bind(&b.cargo_args)
         .bind(b.bpf_flag)
         .bind(&b.arch)

--- a/src/onchain/otter.rs
+++ b/src/onchain/otter.rs
@@ -55,6 +55,11 @@ impl OtterBuildParams {
         self.arg_value("--mount-path")
     }
 
+    /// Gets the workspace path from build arguments
+    pub fn get_workspace_path(&self) -> Option<String> {
+        self.arg_value("--workspace-path")
+    }
+
     /// Gets the library name from build arguments
     pub fn get_library_name(&self) -> Option<String> {
         self.arg_value("--library-name")
@@ -307,6 +312,34 @@ mod tests {
             otter.get_cargo_build_sbf_args().as_deref(),
             Some("--tools-version v1.54")
         );
+    }
+
+    #[test]
+    fn get_workspace_path_from_pda_args() {
+        let otter = OtterBuildParams {
+            address: Pubkey::default(),
+            signer: Pubkey::default(),
+            version: String::new(),
+            git_url: String::new(),
+            commit: String::new(),
+            args: vec![
+                "--mount-path".to_string(),
+                "".to_string(),
+                "--workspace-path".to_string(),
+                "svmgov/program".to_string(),
+                "--library-name".to_string(),
+                "svmgov_program".to_string(),
+            ],
+            deployed_slot: 0,
+            bump: 0,
+        };
+
+        assert_eq!(otter.get_mount_path().as_deref(), Some(""));
+        assert_eq!(
+            otter.get_workspace_path().as_deref(),
+            Some("svmgov/program")
+        );
+        assert_eq!(otter.get_library_name().as_deref(), Some("svmgov_program"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
Description:

  Adds workspace_path support to v2
  - Parses `--workspace-path` from PDA args and persists `workspace_path` on builds
  - Includes `workspace_path` in duplicate detection
  - Passes `--workspace-path` to solana-verify
  - Adds v1.5.5 changelog entry