### PR TITLE
Update solana-verify to v0.5.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY . .
 
 RUN cargo build --release
 
-RUN cargo install solana-verify --git https://github.com/solana-foundation/solana-verifiable-build --tag v0.5.0
+RUN cargo install solana-verify --git https://github.com/solana-foundation/solana-verifiable-build --tag v0.5.1
 
 FROM debian:stable-slim AS api_final
 


### PR DESCRIPTION
This PR updates the solana-verify version in `Dockerfile` to **v0.5.1**.

Triggered from a release in [solana-foundation/solana-verifiable-build](https://github.com/solana-foundation/solana-verifiable-build).

Before merging, please run:
`docker build -f Dockerfile .`