### PR TITLE
v2: cleanup router

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `verified_programs` / `solana_program_builds` / `program_authority` tables → `builds` + `program_state`
   - per-program `solana-verify` hash subprocess → in-process hashing over batched `getMultipleAccounts`
   - hourly status job → drift-driven sweep with automatic re-verification
+- **Webhook endpoints (`/pda`, `/unverify`) are no longer rate-limited** — now gated only by the `AUTHORIZATION` header (previously `/unverify` was capped at 100 req/s).
+
+### Fixed
+
+- **Router middleware no longer leaks across route groups**: rate-limit and CORS layers applied to routes beyond their group (e.g. a GET CORS policy on the POST `/verify*` routes). Each group is now a separate merged router.
 
 
 ## [1.5.5] - 2026-06-29

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6246,6 +6246,7 @@ dependencies = [
  "http 1.4.0",
  "http-body",
  "http-body-util",
+ "mime",
  "pin-project-lite",
  "tokio",
  "tokio-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,10 @@ dotenvy = "0.15.7"
 envy = "0.4.2"
 hex = "0.4"
 moka = { version = "0.12", features = ["future"] }
-reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }
+reqwest = { version = "0.13", default-features = false, features = [
+  "json",
+  "rustls",
+] }
 serde = { version = "1.0.166", features = ["derive"] }
 serde_json = "1.0.99"
 sha2 = "0.11.0"
@@ -21,11 +24,24 @@ solana-pubkey = "4.2.0"
 solana-sdk-ids = "3.1.0"
 solana-signature = "3.4.0"
 solana-transaction-status = "3.1.8"
-sqlx = { version = "0.9", default-features = false, features = ["postgres", "runtime-tokio", "tls-rustls-ring-webpki", "chrono", "uuid", "macros", "migrate"] }
+sqlx = { version = "0.9", default-features = false, features = [
+  "postgres",
+  "runtime-tokio",
+  "tls-rustls-ring-webpki",
+  "chrono",
+  "uuid",
+  "macros",
+  "migrate",
+] }
 thiserror = "2"
 tokio = { version = "1.43.1", features = ["full"] }
 tower = { version = "0.5.3", features = ["limit", "buffer", "util"] }
-tower-http = { version = "0.6", features = ["trace", "cors", "compression-zstd"] }
+tower-http = { version = "0.6", features = [
+  "trace",
+  "cors",
+  "compression-zstd",
+  "validate-request",
+] }
 tower_governor = { version = "0.8.0", features = ["axum"] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.20", features = ["json", "env-filter"] }

--- a/README.md
+++ b/README.md
@@ -101,11 +101,11 @@ curl https://verify.osec.io/resolve-hash/29e7713aa3c48e242e2847bc031fe2a03eb61aa
 
 - **Verification endpoints**: 5 requests/second globally, 1 request per 30 seconds per IP
 - **Status/query endpoints**: 10,000 requests/second globally, 100 requests/second per IP
-- **Unverify endpoint**: 100 requests/second globally
+- **Webhook endpoints** (`/pda`, `/unverify`): not rate limited; require a valid `AUTHORIZATION` header instead
 
 ### Security
 
-To mitigate against false verification results, we rerun program verification every 24 hours. Note that verification should not be considered a strict security boundary.
+To mitigate against false verification results (`matches_deployed` being incorrect), program upgrades are listened for via a Helius webhook to keep `on_chain_hash` in sync. All programs are also fetched every ~5 minutes in case a webhook is missed or a program is closed.
 
 ## Otter Verify PDA Worker
 

--- a/src/api/handlers/pda_worker.rs
+++ b/src/api/handlers/pda_worker.rs
@@ -1,18 +1,14 @@
 use std::str::FromStr;
 
 use crate::{
-    api::handlers::{async_verify::process_verification, is_authorized, parse_helius_transaction},
+    api::handlers::{async_verify::process_verification, parse_helius_transaction},
     db::NewBuild,
     errors::ApiError,
     onchain::{get_on_chain_hash, OtterBuildParams, OTTER_VERIFY_PROGRAM_ID},
     state::AppState,
     types::Address,
 };
-use axum::{
-    extract::State,
-    http::{HeaderMap, StatusCode},
-    Json,
-};
+use axum::{extract::State, http::StatusCode, Json};
 use borsh::BorshDeserialize;
 use serde_json::Value;
 use solana_pubkey::Pubkey;
@@ -20,18 +16,9 @@ use tracing::{error, info, warn};
 
 pub(crate) async fn handle_pda_updates_creations(
     State(state): State<AppState>,
-    headers: HeaderMap,
     Json(payload): Json<Vec<Value>>,
 ) -> (StatusCode, &'static str) {
     info!("Received PDA updates/creation event");
-
-    if !is_authorized(&headers, &state.auth_secret) {
-        warn!("Unauthorized PDA webhook attempt");
-        return (
-            StatusCode::UNAUTHORIZED,
-            "Missing or invalid authorization header",
-        );
-    }
 
     let helius_parsed_transaction = match parse_helius_transaction(&payload) {
         Ok(parsed_transaction) => parsed_transaction,

--- a/src/api/handlers/unverify.rs
+++ b/src/api/handlers/unverify.rs
@@ -1,15 +1,8 @@
 use crate::{
-    api::handlers::{is_authorized, parse_helius_transaction},
-    db::DbClient,
-    onchain::get_on_chain_hash,
-    state::AppState,
-    types::Address,
+    api::handlers::parse_helius_transaction, db::DbClient, onchain::get_on_chain_hash,
+    state::AppState, types::Address,
 };
-use axum::{
-    extract::State,
-    http::{HeaderMap, StatusCode},
-    Json,
-};
+use axum::{extract::State, http::StatusCode, Json};
 use serde_json::Value;
 use solana_client::nonblocking::rpc_client::RpcClient;
 use std::str::FromStr;
@@ -22,19 +15,9 @@ const UPGRADE_INSTRUCTION_DATA: &str = "5Sxr3";
 /// 200 immediately and process in a background task.
 pub async fn handle_unverify(
     State(state): State<AppState>,
-    headers: HeaderMap,
     Json(payload): Json<Vec<Value>>,
 ) -> (StatusCode, &'static str) {
     info!("Received unverify request");
-
-    if !is_authorized(&headers, &state.auth_secret) {
-        warn!("Unauthorized unverify attempt");
-        return (
-            StatusCode::UNAUTHORIZED,
-            "Missing or invalid authorization header",
-        );
-    }
-
     let helius_parsed_transaction = match parse_helius_transaction(&payload) {
         Ok(parsed_transaction) => parsed_transaction,
         Err(status) => return status,

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -1,5 +1,6 @@
 use crate::state::AppState;
 use axum::http::Request;
+use axum::response::IntoResponse;
 use axum::{
     error_handling::HandleErrorLayer,
     http::{Method, StatusCode},
@@ -13,12 +14,13 @@ use tower::{buffer::BufferLayer, limit::RateLimitLayer, ServiceBuilder};
 use tower_governor::{
     governor::GovernorConfigBuilder, key_extractor::SmartIpKeyExtractor, GovernorLayer,
 };
+use tower_http::validate_request::ValidateRequestHeaderLayer;
 use tower_http::{
     compression::CompressionLayer,
     cors::{Any, CorsLayer},
     trace::TraceLayer,
 };
-use tracing::Span;
+use tracing::{warn, Span};
 
 use crate::api::handlers::index::{index, landing_page};
 use crate::api::handlers::*;
@@ -86,9 +88,31 @@ pub fn initialize_router(state: AppState) -> Router {
             },
         );
 
-    // Define routes with their rate limits
-    Router::new()
-        // Verification routes (stricter rate limits)
+    // The `Response` struct is ~130 bytes and required to be returned here, so we have
+    // to allow this clippy lint.
+    #[allow(clippy::result_large_err)]
+    let webhook_auth_layer = {
+        let auth_secret = state.auth_secret.clone();
+        ServiceBuilder::new().layer(ValidateRequestHeaderLayer::custom(
+            move |request: &mut Request<_>| {
+                if !is_authorized(request.headers(), &auth_secret) {
+                    warn!("Unauthorized webhook attempt");
+                    Err((
+                        StatusCode::UNAUTHORIZED,
+                        "Missing or invalid authorization header",
+                    )
+                        .into_response())
+                } else {
+                    Ok(())
+                }
+            },
+        ))
+    };
+
+    // We separate routers to prevent layers from bleeding through to other routes!
+
+    // Verification routes (stricter rate limits).
+    let verify_routes = Router::new()
         .route("/verify", post(process_async_verification))
         .route(
             "/verify-with-signer",
@@ -100,20 +124,15 @@ pub fn initialize_router(state: AppState) -> Router {
                 .layer(CompressionLayer::new().zstd(true))
                 .layer(rate_limit_per_ip(30, 1))
                 .layer(cors(Method::POST)),
-        )
-        .route("/unverify", post(handle_unverify))
-        .layer(
-            global_rate_limit(100)
-                .layer(CompressionLayer::new().zstd(true))
-                .layer(rate_limit_per_ip(1, 100))
-                .layer(cors(Method::POST)),
-        )
+        );
+
+    // Public read routes (looser rate limits).
+    let read_routes = Router::new()
         .route("/status-all/{address}", get(get_verification_status_all))
         .route("/status/{address}", get(get_verification_status))
         .route("/resolve-hash/{hash}", get(resolve_hash::resolve))
         .route("/job/{job_id}", get(get_job_status))
         .route("/logs/{build_id}", get(get_build_logs))
-        .route("/pda", post(handle_pda_updates_creations))
         .route("/verified-programs", get(get_verified_programs_list))
         .route(
             "/verified-programs/{page}",
@@ -128,13 +147,26 @@ pub fn initialize_router(state: AppState) -> Router {
                 .layer(CompressionLayer::new().zstd(true))
                 .layer(rate_limit_per_ip(1, 100))
                 .layer(cors(Method::GET)),
-        )
-        // Base route
+        );
+
+    // Webhook routes require the auth header and carry no rate limits.
+    let webhook_routes = Router::new()
+        .route("/unverify", post(handle_unverify))
+        .route("/pda", post(handle_pda_updates_creations))
+        .layer(webhook_auth_layer);
+
+    // Unmetered base routes.
+    let base_routes = Router::new()
         .route("/", get(|| async { landing_page() }))
         .route("/api", get(|| async { index() }))
         .route("/health", get(health_check))
-        .route("/health/background-jobs", get(background_job_status))
-        // Apply common middleware
+        .route("/health/background-jobs", get(background_job_status));
+
+    Router::new()
+        .merge(verify_routes)
+        .merge(read_routes)
+        .merge(webhook_routes)
+        .merge(base_routes)
         .layer(trace_layer)
         .with_state(state)
 }

--- a/tests/webhooks.rs
+++ b/tests/webhooks.rs
@@ -51,6 +51,20 @@ async fn unverify_without_auth_returns_401() {
     assert_eq!(status, StatusCode::UNAUTHORIZED);
 }
 
+#[tokio::test]
+async fn unverify_with_wrong_auth_returns_401() {
+    let (app, _pg) = boot().await;
+    let (status, _) = post_with_auth(app, "/unverify", "wrong", "[]").await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn unverify_with_correct_auth_but_empty_payload_returns_400() {
+    let (app, _pg) = boot().await;
+    let (status, _) = post_with_auth(app, "/unverify", AUTH_SECRET, "[]").await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
 // --- /unverify behaviour ---------------------------------------------------
 
 /// Builds a Helius "parsed transaction" array containing one upgrade


### PR DESCRIPTION
Pulls the auth checks into tower layers and splits up router so layers don't intersect. Previously routes would end up having mulitple layers of rate limits