### PR TITLE
Fix: Sort verified status-all builds first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.3] - 2026-07-21
+
+### Changed
+
+- **`GET /status-all/{address}` now returns verified builds first**: preserves one selected build per signer while ordering hash-matching entries before unverified entries.
+
 ## [2.0.2] - 2026-07-14
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6558,7 +6558,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "verified_programs_api"
-version = "2.0.2"
+version = "2.0.3"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "verified_programs_api"
-version = "2.0.2"
+version = "2.0.3"
 edition = "2021"
 
 [dependencies]

--- a/src/db.rs
+++ b/src/db.rs
@@ -397,7 +397,8 @@ impl DbClient {
 
     /// One row per signer, preferring their build whose `executable_hash`
     /// matches the on-chain hash (verified), else the most recent. Hash-less
-    /// builds are skipped.
+    /// builds are skipped. The returned rows are ordered with verified builds
+    /// first, then by signer for stable output.
     pub async fn get_all_verification_info(
         &self,
         program_id: Address,

--- a/src/db.rs
+++ b/src/db.rs
@@ -405,12 +405,17 @@ impl DbClient {
         let state = self.get_program_state(&program_id).await?;
         let on_chain_hash = state.as_ref().and_then(|s| s.on_chain_hash.clone());
         let builds = sqlx::query_as::<_, BuildRow>(
-            "SELECT DISTINCT ON (signer) * FROM builds
-             WHERE program_id = $1 AND status = 'completed'
-               AND executable_hash IS NOT NULL
-             ORDER BY signer,
-                      COALESCE(executable_hash = $2::text, false) DESC,
-                      completed_at DESC NULLS LAST",
+            "WITH selected_builds AS (
+                 SELECT DISTINCT ON (signer) * FROM builds
+                 WHERE program_id = $1 AND status = 'completed'
+                   AND executable_hash IS NOT NULL
+                 ORDER BY signer,
+                          COALESCE(executable_hash = $2::text, false) DESC,
+                          completed_at DESC NULLS LAST
+             )
+             SELECT * FROM selected_builds
+             ORDER BY COALESCE(executable_hash = $2::text, false) DESC,
+                      signer",
         )
         .bind(program_id)
         .bind(&on_chain_hash)


### PR DESCRIPTION
Updates `/status-all` to return verified builds before unverified ones.